### PR TITLE
Nuevo comercio

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,6 @@ Tarjeta Mi | Transportation | 5966
 AirBnb | Viajes | 5399
 ||
 JAPAC En línea | Water | 4900 | Compañía de Agua de Culiacán
+||
+Rancho el 17 | Restaurantes | 5422 | Taste Boutique de Carnes, Hermosillo, Sonora. Terminal Adyen
+


### PR DESCRIPTION
Agregué un nuevo comercio que, aunque es un poco nicho, resulta interesante porque combina un supermercado especializado en carnes con un restaurante. A pesar de esta dualidad, el giro registrado parece estar orientado únicamente como restaurante.

Además, incluí en la nota la ubicación y el tipo de terminal utilizada. He notado que en algunos comercios el MCC puede variar dependiendo de la terminal bancaria utilizada, por lo que esta información puede ser útil para futuras referencias.