### PR TITLE
  Agregar 7 nuevos establecimientos comerciales y limpiar formato de tabla

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Uber eats | Delivery services | 4215
 ||
 Sanborns | Departamentales | 5311
 Suburbia | Departamentales | 5311
+Sears | Departamentales | 5311 | Compra en fisico Hermosillo Galerias
 ||
 Platzi Expert | Educación | 8299
 Udemy | Educación | 8999

--- a/README.md
+++ b/README.md
@@ -11,17 +11,12 @@ Comercio | Categoría | MCC | Nota
 -------- | --------- | --- | ----
 Aeroméxico | Aerolíneas | 3076
 Vivaaerobus | Aerolíneas | ? | Didicard cashback
-||
 Tulotero | Apuestas y loterías | 4816
-||
 Pastelería La Esperanza | Bakeries | 5462
-||
 Fraiche | Beauty | 5977
 Studio Frau Mann | Beauty | 7230
-||
 Qeeq | Car rental | 7512
 Hertz web | Car rental | 3357
-||
 GitHub Copilot | Celular, TV e internet | 7372
 Izzi web | Celular, TV e internet | 4899
 Movistar | Celular, TV e internet | 5964 | Mercado Pago
@@ -29,10 +24,8 @@ Starlink | Celular, TV e internet | 5399 | Si te aparece como ‘Internet’, co
 Telcel | Celular, TV e internet | 4814
 Telmex | Celular, TV e internet | 4814
 TotalPlay | Celular, TV e internet | 4814
-||
 Cinépolis | Cine | 7832
 Cinépolis Dulcería | Cine | 7832
-||
 Cielito querido café | Comida rápida | 5814
 Burger king | Comida rápida | 5814
 Domino's Pizza | Comida rápida | 5814
@@ -49,7 +42,6 @@ Tacos El Pata | Comida rápida | 5814
 Taquearte | Comida rápida | 5814
 Taquería La Palmera | Comida rápida | 5814
 Tim Hortons | Comida rápida | 5814
-||
 Amazon | Compras en general | 4816
 AliExpress | Compras en general | 5199, 5311, 5964
 Bosch en linea | Compras en general | 5399
@@ -64,31 +56,25 @@ Riot | Compras en general | 5399 | LoL RP
 Suburbia | Compras en general | 5311
 Suempresa.com | Compras en general | 4816
 Temu | Compras en general | 7399
-||
 DHL | Delivery services | 4215
 Rappi | Delivery services | 4121
 Uber eats | Delivery services | 4215
-||
 Sanborns | Departamentales | 5311
 Suburbia | Departamentales | 5311
 Sears | Departamentales | 5311 | Compra en fisico Hermosillo Galerias
-||
 Platzi Expert | Educación | 8299
 Udemy | Educación | 8999
-||
 App Store & ITunes (suscripción) | Electrónicos | 5818
 Claude.ai | Electrónicos | 5734
 NeWWW | Electrónicos | 4814
 OpenAI | Electrónicos | 5734
 Xbox | Electrónicos | ? | En línea
-||
 Bitcodes.co | Electronics and software | 5816
 Cyberpuerta | Electronics and software | ?
 Google | Electronics and software | 7311
 Nintendo (eShop) | Electronics and software | ?
 Steam | Electronics and software | 5816
 WinCDKeys.com | Electronics and software | 5734
-||
 Boletomovil | Entretenimiento | 5964
 Fever * Candlelight Tri | Entretenimiento | 7922
 Ticketmaster | Entretenimiento | 7996
@@ -96,42 +82,28 @@ TotalPass | Entretenimiento | ?
 Tu polideportivo | Entretenimiento | ?
 Trotime | Entretenimiento | 7941 | maratones
 Vidafel Lp (Cirque Du Soleil Joyá) | Entretenimiento | 7996
-||
 Kigo - Parkimovil | Estacionamiento | 7523
-||
 Farmacias del Ahorro | Farmacias | 5912
 Farmacias Regia | Farmacias | ?
 Farmacias San Francisco de Asís | Farmacias | 5912
 Farmacias Similares | Farmacias | 5912 | Web y tienda
-||
 Multiviveros Cabrera | Flores | 5193
-||
 Gas Oriente | Gas stations | 5541 | Gas LP
 Pemex | Gas stations | 5541
-||
 SACMEX | Gobierno | 9311 | Secretaría de Administración y Finanzas
-||
 Comex | Home and DIY | 5198
 Ferretería García | Home and DIY | 5251
 Home Depot | Home and DIY | 5311
-||
 Joy Mia Amor Palma | Jewelry | 5944
-||
 Marchand | Libros y papelería | 5943
 Sótano | Libros y papelería | 5942
-||
 CFE | Luz | 4900 | Pagado desde app
-||
 Cinépolis | Movie theaters | 7832
-||
 EnvíosPerros | Otro | 4214
 Kidzania Ticket Online | Otro | 7032
 Ross dress for less | Otro | 5310
-||
 Parco | Parking lots | 7523
-||
 UnDosTres | Payments | 4814 
-||
 Barril 23 | Restaurantes | ?
 Bisquets Obregón | Restaurantes | 5812
 Casa de Toño | Restaurantes | 5812
@@ -151,7 +123,6 @@ Twin Peaks | Restaurantes | 5812
 Vips | Restaurantes | 5812 
 William shakes | Restaurantes | ?
 Wingstop | Restaurantes | 5812
-||
 Aldo conty | Ropa | 5611
 Cuidado con el perro | Ropa | ?
 Dorothy Gaynor | Ropa | 5661
@@ -163,13 +134,9 @@ Parisina | Ropa | 5651
 Promoda | Ropa | 5621
 Shasa | Ropa | ?
 Shein | Ropa | 5651 | Si te lo marca como "General purchases" los contactas y aplican el cashback
-||
 Afore Móvil | Servicios Financieros | 4814 | Compra tarjeta de regalo Amazon con Ganahorro |
-||
 Piñatas Los Arcos | Souvenirs | 5947
-||
 Decathlon | Sporting goods | 5941
-||
 Bodega aurrerá | Supermercados | 5411
 CarneMart | Supermercados | ?
 Chedraui | Supermercados | 5411
@@ -187,48 +154,33 @@ Soriana | Supermercados | 5411
 Sumesa | Supermercados | 5411
 Valenti Collezione | Supermercados | 5422 | Cobro entra como "BP*Miscelanea Jarvis" y no entra en ropa a pesar de ser tienda de trajes
 7 Eleven | Supermercados | 5499
-||
 Meli Mas | Suscripciones a medios | 5399
-||
 Amazon Prime | Suscripciones | 4899
 Netflix | Suscripciones | 4899
 Scribd | Suscripciones | 4899
 Spotify | Suscripciones | 4816
 Tidal | Suscripciones | 5815 
 Youtube Premium | Suscripciones | 5818
-||
 Didi Taxi | Taxi | 4121
 Uber | Taxi | 4121
-||
 Movistar (app) | Telecommunication services | 4814
 Telmex (app) | Telecommunication services | 4814
 TotalPlay | Telecommunication services | ? | LikeU dió el 4% 
-||
 Reino de Magos | Tiendas para niños | 5945 | Juegos de mesa y alimentos
-||
 PaySend | Transferencias | 4829
-||
 Conekta*Drive App | Transporte | 4784
 Conekta*Parco | Transporte | 4784
 Primera Plus | Transportation | 4722
 RTC Las Vegas | Transportation | 4111 | Accesos de bus en su app
 Tarjeta Mi | Transportation | 5966
 Vallarta plus | Transportation | 4111
-||
 ADO | Viajes | 4131
 AirBnb | Viajes | 5399
-||
 Supercell store | Videojuegos | ? | Didicard cashback
-||
 JAPAC En línea | Water | 4900 | Compañía de Agua de Culiacán
-||
 Agua de Hermosillo | Water | 4900 | Compañia operaradora Agua potable Hermosillo. Pagado desde APP "Mi Aguah"
-||
 Nikkori Andenes Hermosillo | Fast Food | 5814 | Restaurante Comida Japonesa. TPV Banco Sabadell
-||
 Somos WIM | Compras en General | 5399 | Marca de telefonia digital de AT&T. Utilizan Mercadopago
-||
 Elotes Make | Fastfood | 5814 | Hermosillo Quiroga
-||
 Gua Guaus | Productos para Mascotas | 5995 | Hermosillo Pitic
 

--- a/README.md
+++ b/README.md
@@ -220,3 +220,13 @@ Supercell store | Videojuegos | ? | Didicard cashback
 ||
 JAPAC En línea | Water | 4900 | Compañía de Agua de Culiacán
 ||
+Agua de Hermosillo | Water | 4900 | Compañia operaradora Agua potable Hermosillo. Pagado desde APP "Mi Aguah"
+||
+Nikkori Andenes Hermosillo | Fast Food | 5814 | Restaurante Comida Japonesa. TPV Banco Sabadell
+||
+Somos WIM | Compras en General | 5399 | Marca de telefonia digital de AT&T. Utilizan Mercadopago
+||
+Elotes Make | Fastfood | 5814 | Hermosillo Quiroga
+||
+Gua Guaus | Productos para Mascotas | 5995 | Hermosillo Pitic
+

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Miniso | Supermercados | 5422
 Office Depot | Supermercados | 5411
 Oxxo | Supermercados | 5499
 Seven eleven | Supermercados | ?
+Caffenio | Supermercados | 5812 | Sucursal en Hermosillo
 Soriana  5411
 Sumesa | Supermercados | 5411
 Valenti Collezione | Supermercados | 5422 | Cobro entra como "BP*Miscelanea Jarvis" y no entra en ropa a pesar de ser tienda de trajes

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Office Depot | Supermercados | 5411
 Oxxo | Supermercados | 5499
 Seven eleven | Supermercados | ?
 Caffenio | Supermercados | 5812 | Sucursal en Hermosillo
-Soriana  5411
+Soriana | Supermercados | 5411
 Sumesa | Supermercados | 5411
 Valenti Collezione | Supermercados | 5422 | Cobro entra como "BP*Miscelanea Jarvis" y no entra en ropa a pesar de ser tienda de trajes
 7 Eleven | Supermercados | 5499


### PR DESCRIPTION
## Resumen
Este PR agrega 7 nuevos establecimientos comerciales y mejora la consistencia del formato de la tabla.

## Nuevos Establecimientos Agregados
- **Sears** - Departamentales (MCC 5311) - Compra en físico Hermosillo Galerías
- **Caffenio** - Supermercados (MCC 5812) - Sucursal en Hermosillo
- **Agua de Hermosillo** - Water (MCC 4900) - Compañía operadora Agua potable Hermosillo. Pagado desde APP "Mi Aguah"
- **Nikkori Andenes Hermosillo** - Fast Food (MCC 5814) - Restaurante Comida Japonesa. TPV Banco Sabadell
- **Somos WIM** - Compras en General (MCC 5399) - Marca de telefonía digital de AT&T. Utilizan Mercadopago
- **Elotes Make** - Fastfood (MCC 5814) - Hermosillo Quiroga
- **Gua Guaus** - Productos para Mascotas (MCC 5995) - Hermosillo Pitic

## Mejoras en el Formato de la Tabla
- Corregido el formato de la tabla para la entrada de Soriana (faltaba el separador de categoría)
- Eliminados los 44 separadores de filas vacías (`||`) para un formato de tabla más limpio y consistente